### PR TITLE
fix(issue-9): error when dpe 2387e2058698d is analyzed

### DIFF
--- a/src/5_conso_ventilation.js
+++ b/src/5_conso_ventilation.js
@@ -1,5 +1,4 @@
-import enums from './enums.js'
-import { requestInputID, requestInput } from './utils.js'
+import { requestInput } from './utils.js';
 
 const pvent_moy_maison = {
   'simple flux auto': {
@@ -14,7 +13,7 @@ const pvent_moy_maison = {
     0: 80,
     1: 35
   }
-}
+};
 
 const pvent_immeuble = {
   'simple flux auto': {
@@ -29,17 +28,32 @@ const pvent_immeuble = {
     0: 1.1,
     1: 0.6
   }
+};
+
+/**
+ * Retourne le coefficient en fonction du type d'habitation et du type de ventilation
+ * @param {string} th Type d'habitation (maison ou autre)
+ * @param {boolean} hybride Ventilation hybride ou pas
+ *
+ * @return {number}
+ */
+function getCoefficient(th, hybride) {
+  if (!hybride) {
+    return 1;
+  }
+  const ratio = th === 'maison' ? 14 : 28;
+  return +parseFloat(ratio / (24 * 7)).toFixed(3);
 }
 
-export default function calc_pvent (di, de, du, th) {
-  const tv = requestInput(de, du, 'type_ventilation')
-  let post_2012 = requestInput(de, du, 'ventilation_post_2012', 'bool')
+export default function calc_pvent(di, de, du, th) {
+  const tv = requestInput(de, du, 'type_ventilation');
+  let post_2012 = requestInput(de, du, 'ventilation_post_2012', 'bool');
 
   // can't calculate without these
-  if (tv === undefined || post_2012 === undefined) return
+  if (tv === undefined || post_2012 === undefined) return;
 
-  let hybride = false
-  let type
+  let hybride = false;
+  let type;
   switch (tv) {
     case 'ventilation par ouverture des fenêtres':
     case "ventilation par entrées d'air hautes et basses":
@@ -49,29 +63,36 @@ export default function calc_pvent (di, de, du, th) {
     case 'puits climatique sans échangeur à partir de 2013':
     case 'puits climatique avec échangeur avant 2013':
     case 'puits climatique avec échangeur à partir de 2013':
-      di.conso_auxiliaire_ventilation = 0
-      return
+      di.conso_auxiliaire_ventilation = 0;
+      return;
     case 'ventilation hybride avant  2001':
     case 'ventilation hybride de 2001 à 2012':
     case 'ventilation hybride après 2012':
     case "ventilation hybride avec entrées d'air hygro avant  2001":
     case "ventilation hybride avec entrées d'air hygro de 2001 à 2012":
     case "ventilation hybride avec entrées d'air hygro après 2012":
-      hybride = true
-      post_2012 = 0
+      hybride = true;
+      post_2012 = 0;
+      /**
+       * @see Methode_de_calcul_3CL_DPE_2021-338.pdf, pages 41-42
+       * Les consommations d’auxiliaires pour une VMC hybride correspondent aux consommations d’une VMC
+       * classique autoréglable de 2001 à 2012 multipliées par le ratio du temps d’utilisation
+       */
+      type = 'simple flux auto';
+      break;
     case 'ventilation mécanique sur conduit existant avant 2013':
     case 'ventilation mécanique sur conduit existant à partir de 2013':
     case 'vmc sf auto réglable avant 1982':
     case 'vmc sf auto réglable de 1982 à 2000':
     case 'vmc sf auto réglable de 2001 à 2012':
     case 'vmc sf auto réglable après 2012':
-      type = 'simple flux auto'
-      break
+      type = 'simple flux auto';
+      break;
     case 'vmc sf gaz avant  2001':
     case 'vmc sf gaz de 2001 à 2012':
     case 'vmc sf gaz après 2012':
-      console.error('vmc gaz ??')
-      return
+      console.error('vmc gaz ??');
+      return;
     case 'vmc sf hygro b avant  2001':
     case 'vmc sf hygro b de 2001 à 2012':
     case 'vmc sf hygro b après 2012':
@@ -81,27 +102,25 @@ export default function calc_pvent (di, de, du, th) {
     case 'vmc basse pression auto-réglable':
     case 'vmc basse pression hygro a':
     case 'vmc basse pression hygro b':
-      type = 'simple flux hygro'
-      break
+      type = 'simple flux hygro';
+      break;
     case 'vmc df individuelle avec échangeur avant 2013':
     case 'vmc df individuelle avec échangeur à partir de 2013':
     case 'vmc df collective avec échangeur avant 2013':
     case 'vmc df collective avec échangeur à partir de 2013':
     case 'vmc df sans échangeur avant 2013':
     case 'vmc df sans échangeur après 2012':
-      type = 'double flux'
-      break
+      type = 'double flux';
+      break;
   }
 
-  let coef = 1
+  const coef = getCoefficient(th, hybride);
   if (th === 'maison') {
-    if (hybride) coef = 14 / (24 * 7)
-    di.pvent_moy = pvent_moy_maison[type][post_2012] * coef
+    di.pvent_moy = parseFloat(pvent_moy_maison[type][post_2012] * coef).toFixed(3);
   } else {
-    if (hybride) coef = 28 / (24 * 7)
-    const pvent = pvent_immeuble[type][post_2012]
-    const sv = requestInput(de, du, 'surface_ventile', 'float')
-    di.pvent_moy = pvent * di.qvarep_conv * sv * coef
+    const pvent = pvent_immeuble[type][post_2012];
+    const sv = requestInput(de, du, 'surface_ventile', 'float');
+    di.pvent_moy = parseFloat(pvent * di.qvarep_conv * sv * coef).toFixed(3);
   }
-  di.conso_auxiliaire_ventilation = 8.76 * di.pvent_moy
+  di.conso_auxiliaire_ventilation = 8.76 * di.pvent_moy;
 }


### PR DESCRIPTION
Correction du ticket #9 

Le type de ventilation pour ce DPE n'était pas renseignée. Impossible de trouver les valeurs par la suite, on cherchait avec un index undefined.

D'après le document Methode_de_calcul_3CL_DPE_2021-338.pdf, pages 41-42 

> Les consommations d’auxiliaires pour une VMC hybride correspondent aux consommations d’une VMC classique autoréglable de 2001 à 2012 multipliées par le ratio du temps d’utilisation

On utilise donc le type 'simple flux auto'.

Le fichier passe bien maintenant.

J'en ai profité pour gérer les arrondis (problème de virgule flottante en js).