### PR TITLE
chore: remove typo in code

### DIFF
--- a/scripts/synchronize_assets.js
+++ b/scripts/synchronize_assets.js
@@ -19,6 +19,4 @@ const synchronizeValeurTables = new SynchronizeValeurTables(
 );
 const synchronizeAssets = new SynchronizeAssets(synchronizeEnumTables, synchronizeValeurTables);
 
-await synchronizeC1Tables.execute();
-
 await synchronizeAssets.execute();


### PR DESCRIPTION
Petit correctif,j'ai oublié d'enlever un appel à `synchronizeC1Tables` qui n'est pas nécessaire