### PR TITLE
fix: script name detection does not work in browser

### DIFF
--- a/src/3.2.1_mur.js
+++ b/src/3.2.1_mur.js
@@ -2,11 +2,7 @@ import enums from './enums.js';
 import { tv, requestInput, requestInputID, getKeyByValue, bug_for_bug_compat } from './utils.js';
 import b from './3.1_b.js';
 
-import * as path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const scriptName = path.basename(__filename);
+const scriptName = new URL(import.meta.url).pathname.split('/').pop();
 
 function tv_umur0(di, de, du) {
   const matcher = {

--- a/src/3.2.2_plancher_bas.js
+++ b/src/3.2.2_plancher_bas.js
@@ -2,10 +2,7 @@ import enums from './enums.js';
 import b from './3.1_b.js';
 import { tv, requestInput, requestInputID, getKeyByValue, bug_for_bug_compat } from './utils.js';
 
-import * as path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
+const scriptName = new URL(import.meta.url).pathname.split('/').pop();
 
 function tv_upb0(di, de, du) {
   requestInput(de, du, 'type_plancher_bas');
@@ -192,7 +189,6 @@ export default function calc_pb(pb, zc, pc_id, ej, pb_list) {
       const tv_upb_avant = de.tv_upb_id;
       tv_upb(di, de, du, pi_id, zc, ej);
       if (de.tv_upb_id != tv_upb_avant && pi_id != pc_id) {
-        const scriptName = path.basename(__filename);
         console.warn(
           `BUG(${scriptName}) Si année de construction <74 alors Année d'isolation=75-77 (3CL page 17)`
         );

--- a/src/3.2.3_plancher_haut.js
+++ b/src/3.2.3_plancher_haut.js
@@ -2,11 +2,7 @@ import enums from './enums.js';
 import b from './3.1_b.js';
 import { tv, requestInput, getKeyByValue, bug_for_bug_compat } from './utils.js';
 
-import * as path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const scriptName = path.basename(__filename);
+const scriptName = new URL(import.meta.url).pathname.split('/').pop();
 
 function tv_uph0(di, de, du) {
   requestInput(de, du, 'type_plancher_haut');

--- a/src/4_ventilation.js
+++ b/src/4_ventilation.js
@@ -2,11 +2,7 @@ import enums from './enums.js';
 import { tv, requestInputID, requestInput, bug_for_bug_compat } from './utils.js';
 import calc_pvent from './5_conso_ventilation.js';
 
-import * as path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const scriptName = path.basename(__filename);
+const scriptName = new URL(import.meta.url).pathname.split('/').pop();
 
 function tv_debits_ventilation(di, de, du) {
   const matcher = {


### PR DESCRIPTION
Dans certains fichiers on détecte le nom du fichier js courant pour pouvoir logger.

Or ca ne fonctionne pas quand on charge la lib dans un navigateur (ca fonctionne en mode node js)

J'ai fait une modification qui devrait marcher dans les deux cas