### PR TITLE
fix: perf - optimize tvmatch function in utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,15 @@ export function set_bug_for_bug_compat() {
   bug_for_bug_compat = true;
 }
 
+export let tv_match_new_version = false;
+export function set_tv_match_optimized_version() {
+  tv_match_new_version = true;
+}
+
+export function unset_tv_match_optimized_version() {
+  tv_match_new_version = false;
+}
+
 export const Tbase = {
   'inférieur à 400m': {
     h1: -9.5,
@@ -162,6 +171,9 @@ export function tvColumnLines(filePath, column, matcher) {
 }
 
 function tvMatch(row, key, matcher) {
+  if (tv_match_new_version) {
+    return tvMatchOptimized(row, key, matcher);
+  }
   if (!row.hasOwnProperty(key)) {
     // for empty csv columns
     // for q4pa_conv
@@ -187,6 +199,38 @@ function tvMatch(row, key, matcher) {
     return false;
   }
   return true;
+}
+
+function tvMatchOptimized(row, key, matcher) {
+  if (!row[key]) {
+    // for empty csv columns
+    // for q4pa_conv
+    return false;
+  }
+
+  let row_value = row[key].toLowerCase();
+  let match_value = String(matcher[key]).toLowerCase();
+
+  if (row_value === match_value) {
+    return true;
+  }
+
+  if (match_value.startsWith('^')) {
+    const match_value_no_regex = match_value.replace('^', '').replace('$', '');
+    if (row_value === match_value_no_regex) {
+      return true;
+    }
+  }
+
+  if (isNaN(matcher[key]) && row_value.includes(match_value)) {
+    return true;
+  }
+
+  if (row_value.includes('|')) {
+    return row_value.split('|').includes(match_value);
+  }
+
+  return row_value.includes(match_value);
 }
 
 export function tv(filePath, matcher) {

--- a/test/open3cl_tv_optimized.spec.js
+++ b/test/open3cl_tv_optimized.spec.js
@@ -1,0 +1,21 @@
+import { calcul_3cl } from '../src/engine.js';
+import corpus from './corpus.json';
+import { getAdemeFileJson } from './test-helpers.js';
+import { set_tv_match_optimized_version, unset_tv_match_optimized_version } from '../src/utils.js';
+
+describe('Test Open3CL tvMatch function refactoring on corpus', () => {
+  it('Both old and optimized tvMatch functions should produce same results', () => {
+    for (let codeDpe of corpus) {
+      const dpeRequest = getAdemeFileJson(codeDpe);
+      unset_tv_match_optimized_version();
+      const resultsWithOldTvMatch = calcul_3cl(structuredClone(dpeRequest));
+      set_tv_match_optimized_version();
+      const resultsWithNewTvMatch = calcul_3cl(structuredClone(dpeRequest));
+      try {
+        expect(resultsWithOldTvMatch).toStrictEqual(resultsWithNewTvMatch);
+      } catch (error) {
+        throw new Error(`Dpe ${codeDpe} does not match`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
### Amélioration des perfs

Après analyse la méthode `tvMatch` semble etre une des sources principales de lenteur lié au fait qu'elle est appelée souvent et qu'elle utilise les expression regulières.

Je l'ai dupliquée et optimisée et j'ai crée une nouvelle méthode: `tvOptimized` qui n'est pas activée par défaut pour l'instant (il faut l'activer par le code)
J'ai crée un test unitaire qui lance tout le corpus avec l'ancienne version de la fonction et la nouvelle version pou vérifier qu'il n'y ai pas de différence de sorties.

Au niveau des perfs on divise à peu pres par 2 le temps d'éxecution.