### PR TITLE
chore: force comparison typing

### DIFF
--- a/src/13.2_generateur_combustion_ch.js
+++ b/src/13.2_generateur_combustion_ch.js
@@ -151,7 +151,7 @@ export function calc_generateur_combustion_ch(di, de, du, em_ch, GV, ca_id, zc_i
 
   tv_generateur_combustion(di, de, du, 'ch', GV, tbase);
   const type_gen_ch_list = tvColumnIDs('temp_fonc_30', 'type_generateur_ch');
-  if (type_gen_ch_list.includes(de.enum_type_generateur_ch_id)) {
+  if (type_gen_ch_list.includes(de.enum_type_generateur_ch_id.toString())) {
     tv_temp_fonc_30_100(di, de, du, em_ch, ac);
   }
 

--- a/src/14_generateur_ecs.js
+++ b/src/14_generateur_ecs.js
@@ -57,7 +57,7 @@ function calc_Qgw(di, de, du) {
   }
   const Vs = requestInput(de, du, 'volume_stockage', 'float');
   const gen_ecs_elec_ids = tvColumnIDs('pertes_stockage', 'type_generateur_ecs');
-  if (gen_ecs_elec_ids.includes(de.enum_type_generateur_ecs_id)) {
+  if (gen_ecs_elec_ids.includes(de.enum_type_generateur_ecs_id.toString())) {
     tv_pertes_stockage(di, de, du);
     di.Qgw = ((8592 * 45) / 24) * Vs * di.cr;
     delete di.cr;

--- a/src/2021_04_13_qualite_isolation.js
+++ b/src/2021_04_13_qualite_isolation.js
@@ -17,21 +17,22 @@ export default function calc_qualite_isolation(enveloppe, dp) {
   const porte_list = enveloppe.porte_collection.porte || [];
   const plancher_haut_ca = ph_list.filter(
     (ph) =>
-      ph.donnee_entree.enum_type_adjacence_id ===
+      ph.donnee_entree.enum_type_adjacence_id.toString() ===
         getKeyByValue(enums.type_adjacence, 'extérieur') &&
-      ph.donnee_entree.enum_type_plancher_haut ===
+      ph.donnee_entree.enum_type_plancher_haut.toString() ===
         getKeyByValue(enums.type_plancher_haut, 'combles aménagés sous rampant')
   );
   const plancher_haut_tt = ph_list.filter(
     (ph) =>
-      ph.donnee_entree.enum_type_adjacence_id ===
+      ph.donnee_entree.enum_type_adjacence_id.toString() ===
         getKeyByValue(enums.type_adjacence, 'extérieur') &&
-      ph.donnee_entree.enum_type_plancher_haut !=
+      ph.donnee_entree.enum_type_plancher_haut.toString() !==
         getKeyByValue(enums.type_plancher_haut, 'combles aménagés sous rampant')
   );
   const plancher_haut_cp = ph_list.filter(
     (ph) =>
-      ph.donnee_entree.enum_type_adjacence_id != getKeyByValue(enums.type_adjacence, 'extérieur')
+      ph.donnee_entree.enum_type_adjacence_id.toString() !==
+      getKeyByValue(enums.type_adjacence, 'extérieur')
   );
 
   // mur

--- a/src/3.1_b.js
+++ b/src/3.1_b.js
@@ -33,7 +33,7 @@ export default function b(di, de, du, zc_id) {
     enum_type_adjacence_id: requestInputID(de, du, 'type_adjacence')
   };
 
-  if (de.enum_type_adjacence_id === '10') {
+  if (de.enum_type_adjacence_id.toString() === '10') {
     matcher.zone_climatique = zc;
     matcher.enum_cfg_isolation_lnc_id = requestInputID(de, du, 'cfg_isolation_lnc');
     /* du.enum_cfg_isolation_lnc_id = ['6', '7', '8', '9', '10', '11'] */
@@ -50,7 +50,7 @@ export default function b(di, de, du, zc_id) {
       return;
     }
     matcher.enum_cfg_isolation_lnc_id = requestInputID(de, du, 'cfg_isolation_lnc');
-    if (matcher.enum_cfg_isolation_lnc_id === '1') {
+    if (matcher.enum_cfg_isolation_lnc_id.toString() === '1') {
       // local chauffé non accessible
       // aiu/aue non connu
       delete matcher.enum_type_adjacence_id;

--- a/src/3.2.2_plancher_bas.js
+++ b/src/3.2.2_plancher_bas.js
@@ -118,7 +118,7 @@ function tv_ue(di, de, du, pc_id, pb_list) {
   const delta_ue = Number(row_2.ue) - Number(row_1.ue);
   const delta_upb = upb2 - upb1;
   let ue;
-  if (delta_upb == 0) ue = Number(row_1.ue);
+  if (delta_upb === 0) ue = Number(row_1.ue);
   else ue = Number(row_1.ue) + (delta_ue * (di.upb - upb1)) / delta_upb;
   de.ue = ue;
 }
@@ -192,7 +192,7 @@ export default function calc_pb(pb, zc, pc_id, ej, pb_list) {
       calc_upb0(di, de, du);
       const tv_upb_avant = de.tv_upb_id;
       tv_upb(di, de, du, pi_id, zc, ej);
-      if (de.tv_upb_id != tv_upb_avant && pi_id != pc_id) {
+      if (de.tv_upb_id !== tv_upb_avant && pi_id !== pc_id) {
         console.warn(
           `BUG(${scriptName}) Si année de construction <74 alors Année d'isolation=75-77 (3CL page 17)`
         );

--- a/src/3.2.3_plancher_haut.js
+++ b/src/3.2.3_plancher_haut.js
@@ -24,9 +24,9 @@ function tv_uph(di, de, du, pc_id, zc, ej) {
   let type_toiture;
 
   // From "3CL-DPE 2021" page 21 => "Lorsque le local au-dessus du logement est un local non chauffé, ou un local autre que d’habitation., Uph_tab est pris dans la catégorie « Terrasse »."
-  if (type_adjacence == 'locaux non chauffés non accessible') {
+  if (type_adjacence === 'locaux non chauffés non accessible') {
     type_toiture = 'terrasse';
-  } else if (type_adjacence != 'extérieur') {
+  } else if (type_adjacence !== 'extérieur') {
     type_toiture = 'combles';
   } else {
     if (type_ph === 'combles aménagés sous rampant') type_toiture = 'combles';

--- a/src/3.3_baie_vitree.js
+++ b/src/3.3_baie_vitree.js
@@ -6,7 +6,7 @@ function tv_ug(di, de, du) {
     enum_type_vitrage_id: requestInputID(de, du, 'type_vitrage')
   };
 
-  if (matcher.enum_type_vitrage_id && matcher.enum_type_vitrage_id != '1') {
+  if (matcher.enum_type_vitrage_id && matcher.enum_type_vitrage_id.toString() !== '1') {
     // inside if because simple vitrage does not have these fields
     matcher.enum_type_gaz_lame_id = requestInputID(de, du, 'type_gaz_lame');
     matcher.enum_inclinaison_vitrage_id = requestInputID(de, du, 'inclinaison_vitrage');
@@ -150,7 +150,7 @@ export default function calc_bv(bv, zc) {
   else tv_uw(di, de, du);
 
   const type_fermeture = requestInput(de, du, 'type_fermeture');
-  if (type_fermeture != 'abscence de fermeture pour la baie vitrée') {
+  if (type_fermeture !== 'abscence de fermeture pour la baie vitrée') {
     tv_ujn(di, de, du);
     di.u_menuiserie = di.ujn;
   } else {

--- a/src/4_ventilation.js
+++ b/src/4_ventilation.js
@@ -114,8 +114,9 @@ export default function calc_ventilation(vt, cg, th, Sdep, mur_list, ph_list, po
   let Sh = requestInput(de, du, 'surface_ventile', 'float');
 
   if (Sh === undefined) {
-    if (th === 'maison' || th === 'appartement') Sh = cg.surface_habitable_logement;
-    else if (th === 'immeuble') Sh = cg.surface_habitable_immeuble;
+    if (th.toString() === 'maison' || th.toString() === 'appartement')
+      Sh = cg.surface_habitable_logement;
+    else if (th.toString() === 'immeuble') Sh = cg.surface_habitable_immeuble;
   }
 
   const Hsp = cg.hsp;

--- a/src/6.2_surface_sud_equivalente.js
+++ b/src/6.2_surface_sud_equivalente.js
@@ -7,14 +7,14 @@ export function calc_sse_j(bv_list, zc, mois) {
 
   const ssej = bv_list.reduce((acc, bv) => {
     const type_adjacence = enums.type_adjacence[bv.donnee_entree.enum_type_adjacence_id];
-    if (type_adjacence != 'extérieur') return acc;
+    if (type_adjacence !== 'extérieur') return acc;
     const de = bv.donnee_entree;
     const di = bv.donnee_intermediaire;
 
     const orientation = enums.orientation[de.enum_orientation_id];
     const inclinaison = enums.inclinaison_vitrage[de.enum_inclinaison_vitrage_id];
     let oi = `${orientation} ${inclinaison}`;
-    if (inclinaison == 'horizontal') oi = 'horizontal';
+    if (inclinaison === 'horizontal') oi = 'horizontal';
     const c1j = c1[zc][mois][oi];
 
     const fe1 = di.fe1;

--- a/src/7_inertie.js
+++ b/src/7_inertie.js
@@ -74,13 +74,13 @@ export default function calc_inertie(enveloppe) {
     inertie.inertie_plancher_haut_lourd +
     inertie.inertie_paroi_verticale_lourd;
 
-  if (nb_inertie_lourde == 0) {
+  if (nb_inertie_lourde === 0) {
     inertie.enum_classe_inertie_id = getKeyByValue(enums.classe_inertie, 'légère');
-  } else if (nb_inertie_lourde == 1) {
+  } else if (nb_inertie_lourde === 1) {
     inertie.enum_classe_inertie_id = getKeyByValue(enums.classe_inertie, 'moyenne');
-  } else if (nb_inertie_lourde == 2) {
+  } else if (nb_inertie_lourde === 2) {
     inertie.enum_classe_inertie_id = getKeyByValue(enums.classe_inertie, 'lourde');
-  } else if (nb_inertie_lourde == 3) {
+  } else if (nb_inertie_lourde === 3) {
     inertie.enum_classe_inertie_id = getKeyByValue(enums.classe_inertie, 'très lourde');
   }
 

--- a/src/9_conso_ch.js
+++ b/src/9_conso_ch.js
@@ -58,7 +58,7 @@ export function conso_ch(di, de, du, _pos, cfg_ch, em_list, GV, Sh, hsp, bch, bc
   const coef = coef_ch(0.5)[cfg_ch][_pos];
 
   const em_filt = em_list.filter(
-    (em) => em.donnee_entree.enum_lien_generateur_emetteur_id === gen_lge_id
+    (em) => em.donnee_entree.enum_lien_generateur_emetteur_id.toString() === gen_lge_id.toString()
   );
 
   const emetteur_eq = em_filt.reduce((acc, em) => {

--- a/src/9_emetteur_ch.js
+++ b/src/9_emetteur_ch.js
@@ -63,7 +63,7 @@ function tv_intermittence(di, de, inst_ch_de, map_id, inertie_id) {
   // Pas de valeur d'inertie pour les méthodes d'applications différentes de "dpe maison individuelle"
   // dans le fichier de table de valeur sur l'onglet "intermittence", si on le précise on ne trouve aucune correspondance
   // et la mauvaise valeur est sélectionnée
-  if (map_id === '1') {
+  if (map_id.toString() === '1') {
     matcher.enum_classe_inertie_id = inertie_id;
   }
 

--- a/src/9_generateur_ch.js
+++ b/src/9_generateur_ch.js
@@ -103,7 +103,9 @@ export function calc_generateur_ch(
   const combustion_ids = tvColumnIDs('generateur_combustion', 'type_generateur_ch');
   if (pac_ids.includes(type_gen_ch_id)) {
     const gen_lge_id = requestInputID(de, du, 'lien_generateur_emetteur');
-    const em = em_ch.find((em) => em.donnee_entree.enum_lien_generateur_emetteur_id === gen_lge_id);
+    const em = em_ch.find(
+      (em) => em.donnee_entree.enum_lien_generateur_emetteur_id.toString() === gen_lge_id
+    );
     const ed_id = em.donnee_entree.enum_type_emission_distribution_id;
     tv_scop(di, de, du, zc_id, ed_id, 'ch');
   } else if (combustion_ids.includes(type_gen_ch_id)) {

--- a/src/apport_et_besoin.js
+++ b/src/apport_et_besoin.js
@@ -23,8 +23,8 @@ export default function calc_apport_et_besoin(
 
   const bv = enveloppe.baie_vitree_collection.baie_vitree;
   let nadeq;
-  if (th == 'maison') nadeq = calc_nadeq_individuel(Sh, Nb_lgt);
-  else if (th == 'appartement') nadeq = calc_nadeq_collectif(Sh, 1);
+  if (th.toString() === 'maison') nadeq = calc_nadeq_individuel(Sh, Nb_lgt);
+  else if (th.toString() === 'appartement') nadeq = calc_nadeq_collectif(Sh, 1);
   else nadeq = calc_nadeq_collectif(Sh, Nb_lgt);
   const besoin_ecs = calc_besoin_ecs(ilpa, ca, zc, Sh, nadeq);
   const besoin_fr = calc_besoin_fr(ilpa, ca, zc, Sh, nadeq, GV, inertie, bv);

--- a/src/conso.js
+++ b/src/conso.js
@@ -122,10 +122,10 @@ export default function calc_conso(Sh, zc_id, ca_id, vt, ch, ecs, fr) {
       fr_en = [];
     }
     const gen_ch_en = gen_ch.filter(
-      (gen_ch) => gen_ch.donnee_entree.enum_type_energie_id == type_energie
+      (gen_ch) => gen_ch.donnee_entree.enum_type_energie_id.toString() === type_energie
     );
     const gen_ecs_en = gen_ecs.filter(
-      (gen_ecs) => gen_ecs.donnee_entree.enum_type_energie_id == type_energie
+      (gen_ecs) => gen_ecs.donnee_entree.enum_type_energie_id.toString() === type_energie
     );
     let conso_en = calc_conso_pond(Sh, zc_id, vt_en, gen_ch_en, gen_ecs_en, fr_en, '', null);
     conso_en = {
@@ -152,7 +152,7 @@ function classe_bilan_dpe(ep_conso_5_usages_m2, zc_id, ca_id) {
   const zc = enums.zone_climatique[zc_id];
   const ca = enums.classe_altitude[ca_id];
 
-  if (['h1b', 'h1c', 'h2d'].includes(zc) && ca == 'supérieur à 800m') {
+  if (['h1b', 'h1c', 'h2d'].includes(zc) && ca === 'supérieur à 800m') {
     if (ep_conso_5_usages_m2 < 390) return 'E';
     if (ep_conso_5_usages_m2 < 500) return 'F';
   } else {
@@ -172,7 +172,7 @@ function classe_emission_ges(emission_ges_5_usages_m2, zc_id, ca_id) {
   const zc = enums.zone_climatique[zc_id];
   const ca = enums.classe_altitude[ca_id];
 
-  if (['h1b', 'h1c', 'h2d'].includes(zc) && ca == 'supérieur à 800m') {
+  if (['h1b', 'h1c', 'h2d'].includes(zc) && ca === 'supérieur à 800m') {
     if (emission_ges_5_usages_m2 < 80) return 'E';
     if (emission_ges_5_usages_m2 < 110) return 'F';
   } else {
@@ -269,7 +269,7 @@ function calc_conso_pond(Sh, zc_id, vt_list, gen_ch, gen_ecs, fr_list, prefix, c
     ret.auxiliaire_distribution_ch +
     ret.auxiliaire_distribution_ecs;
   ret['5_usages'] = ret.ch + ret.ecs + ret.fr + ret[tot_aux] + ret.eclairage;
-  if (prefix != 'cout') ret['5_usages_m2'] = Math.floor(ret['5_usages'] / Sh);
+  if (prefix !== 'cout') ret['5_usages_m2'] = Math.floor(ret['5_usages'] / Sh);
 
   // add prefix_ to all ret keys
   Object.keys(ret).forEach((key) => {

--- a/src/engine.js
+++ b/src/engine.js
@@ -22,7 +22,7 @@ function calc_th(map_id) {
 export function calcul_3cl(dpe) {
   sanitize_dpe(dpe);
   const modele = enums.modele_dpe[dpe.administratif.enum_modele_dpe_id];
-  if (modele != 'dpe 3cl 2021 méthode logement') {
+  if (modele !== 'dpe 3cl 2021 méthode logement') {
     console.error('Moteur dpe non implémenté pour le modèle: ' + modele);
     return null;
   }
@@ -56,8 +56,8 @@ export function calcul_3cl(dpe) {
 
   const instal_ch = logement.installation_chauffage_collection.installation_chauffage;
   const ej =
-    instal_ch[0].generateur_chauffage_collection.generateur_chauffage[0].donnee_entree
-      .enum_type_energie_id === '1'
+    instal_ch[0].generateur_chauffage_collection.generateur_chauffage[0].donnee_entree.enum_type_energie_id.toString() ===
+    '1'
       ? '1'
       : '0';
 
@@ -68,7 +68,9 @@ export function calcul_3cl(dpe) {
   const inertie_id = env.inertie.enum_classe_inertie_id;
   const inertie = enums.classe_inertie[inertie_id];
   const ilpa =
-    logement.meteo.batiment_materiaux_anciens === 1 && inertie.includes('lourde') ? '1' : '0';
+    logement.meteo.batiment_materiaux_anciens.toString() === '1' && inertie.includes('lourde')
+      ? '1'
+      : '0';
 
   const ecs = logement.installation_ecs_collection.installation_ecs || [];
   const Nb_lgt = cg.nombre_appartement || 1;


### PR DESCRIPTION
@jzck , je force le typage des valeurs afin d'éviter quelques problèmes de comparaisons.

En effet, "1" === 1 retourne faux en JS et "1" == 1 n'est pas conseillé (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Operators/Strict_equality)