### PR TITLE
fix(issue-101): Use tunnel as type_pose when type_pose === 'sans objet'

### DIFF
--- a/src/3.4_pont_thermique.js
+++ b/src/3.4_pont_thermique.js
@@ -142,7 +142,12 @@ function tv_k(di, de, du, pc_id, enveloppe) {
       const mde = menuiserie.donnee_entree;
       const mdu = menuiserie.donnee_utilisateur;
 
-      matcher.type_pose = requestInput(mde, mdu, 'type_pose') || 'tunnel';
+      let type_pose = requestInput(mde, mdu, 'type_pose') || 'tunnel';
+      if (type_pose.includes('sans objet')) {
+        type_pose = 'tunnel';
+      }
+
+      matcher.type_pose = type_pose;
       matcher.presence_retour_isolation = requestInput(
         mde,
         mdu,


### PR DESCRIPTION
Close https://github.com/jzck/Open3CL/issues/101