### PR TITLE
fix: Match row using input data instead of tv_*

### DIFF
--- a/src/13.2_generateur_combustion.js
+++ b/src/13.2_generateur_combustion.js
@@ -49,48 +49,40 @@ function excel_to_js_exec(box, pn, E, F) {
 }
 
 export function tv_generateur_combustion(di, de, du, type, GV, tbase) {
-  let matcher = {};
   const typeGenerateur = `enum_type_generateur_${type}_id`;
   const enum_type_generateur_id = de[typeGenerateur];
-  matcher[typeGenerateur] = enum_type_generateur_id;
 
-  if (!di.pn) {
-    // some engines don't set ms_carac_sys properly...
-    // so instead we just check if di.pn is set or not
-    di.pn = (1.2 * GV * (19 - tbase)) / 0.95 ** 3;
-  }
-
-  matcher.critere_pn = criterePn(di.pn / 1000, matcher);
-  let row = tv('generateur_combustion', matcher);
+  let row;
 
   /**
    * Si le type de générateur est
    * 84 - ECS - système collectif par défaut en abscence d'information : chaudière fioul pénalisante
    * 119 - CH - système collectif par défaut en abscence d'information : chaudière fioul pénalisante
    * On garde l'information à partir de tv_generateur_combustion_id.
-   * Si non, on vérifie que le générateur décrit fait bien partie des générateurs associés pour tv_generateur_combustion_id spécifié
    */
-  if (
-    bug_for_bug_compat &&
-    (
-      (type === 'ecs' && enum_type_generateur_id === '84')
-      || (type === 'ch' && enum_type_generateur_id === '119')
-    ) &&
-    de.tv_generateur_combustion_id
+  if (bug_for_bug_compat && (
+    (type === 'ecs' && enum_type_generateur_id === '84')
+    || (type === 'ch' && enum_type_generateur_id === '119')
+  ) && de.tv_generateur_combustion_id
   ) {
     const tv_row = tv('generateur_combustion', {
       tv_generateur_combustion_id: de.tv_generateur_combustion_id
     });
-    /* On vérifie que le tv_ est différent de celui trouvé par la table forfaitaire
-     * et qu'il est compatible avec le générateur.
-     */
-    if (
-      tv_row.tv_generateur_combustion_id !== row.tv_generateur_combustion_id &&
-      (tv_row[typeGenerateur]?.split('|')?.includes(enum_type_generateur_id) ?? false)
-    ) {
-      console.warn('Bug compat. Utilisation du tv_generateur_combustion fourni');
-      row = tv_row;
+    console.warn(
+      `Utilisation de tv_generateur_combustion_id pour le générateur ${de.description}.`
+    );
+    row = tv_row;
+  } else {
+    if (!di.pn) {
+      // some engines don't set ms_carac_sys properly...
+      // so instead we just check if di.pn is set or not
+      di.pn = (1.2 * GV * (19 - tbase)) / 0.95 ** 3;
     }
+
+    let matcher = {};
+    matcher[typeGenerateur] = enum_type_generateur_id;
+    matcher.critere_pn = criterePn(di.pn / 1000, matcher);
+    row = tv('generateur_combustion', matcher);
   }
 
   if (!row) console.error('!! pas de valeur forfaitaire trouvée pour generateur_combustion !!');


### PR DESCRIPTION
Ex: 2459E3195669T
Le generateur_ecs.tv_generateur_combustion_id présent dans le xml est erroné et génère un qp0 faux (et tout ce qui en découle) Il faut trouver le bon tv avec les infos présentent dans donnee_entree