### PR TITLE
Autofix: Le type d'adjacence pour les planchers hauts est souvent mal renseigné

### DIFF
--- a/src/3.2.3_plancher_haut.js
+++ b/src/3.2.3_plancher_haut.js
@@ -18,8 +18,20 @@ function tv_uph0(di, de, du) {
   }
 }
 
-function tv_uph(di, de, du, pc_id, zc, ej) {
+function verifyAdjacencyType(de, du) {
   const type_adjacence = requestInput(de, du, 'type_adjacence');
+  const type_ph = requestInput(de, du, 'type_plancher_haut');
+
+  if (type_ph === 'combles aménagés sous rampant' && type_adjacence === 'extérieur') {
+    console.warn('Adjacency type mismatch detected for attic');
+    return 'locaux non chauffés non accessible';
+  }
+
+  return type_adjacence;
+}
+
+  const type_adjacence = verifyAdjacencyType(de, du);
+  de.type_adjacence = type_adjacence; // Update the input data with verified adjacency type
   const type_ph = requestInput(de, du, 'type_plancher_haut');
   let type_toiture;
 
@@ -33,7 +45,11 @@ function tv_uph(di, de, du, pc_id, zc, ej) {
     else type_toiture = 'terrasse';
   }
 
-  if (de.description?.includes("donnant sur l'extérieur (combles aménagés)")) {
+  // Remove this check as it's now handled by verifyAdjacencyType
+  // if (de.description?.includes("donnant sur l'extérieur (combles aménagés)")) {
+  //   console.warn(`BUG(${scriptName}) extérieur != combles`);
+  //   if (bug_for_bug_compat) type_toiture = 'combles';
+  // }
     // cf 2287E1327399F
     // this is bullshit, by definition this is bullshit, how can someone have written this
     // "combles aménagés" should be "local non chauffé" or some shit, deifnitely not extérieur


### PR DESCRIPTION
Added logic to verify and correct the adjacency type for upper floors, especially for attics, based on other available information. This addresses the issue of incorrectly specified adjacency types. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    