### PR TITLE
Autofix: Calcul des Umur pour 'isolation inconnue  (table forfaitaire)' - effet joule non pris en compte

### DIFF
--- a/src/3.2.1_mur.js
+++ b/src/3.2.1_mur.js
@@ -147,11 +147,12 @@ export default function calc_mur(mur, zc, pc_id, ej) {
       di.umur = 1 / (1 / Number(di.umur0) + r);
       break;
     }
-    case 'isolation inconnue  (table forfaitaire)':
+    case 'isolation inconnue  (table forfaitaire)': {
       calc_umur0(di, de, du);
-      tv_umur(di, de, du, pc_id, zc);
+      tv_umur(di, de, du, pc_id, zc, ej);
       di.umur = Math.min(di.umur, di.umur0);
       break;
+    }
     case "année d'isolation différente de l'année de construction saisie justifiée (table forfaitaire)": {
       calc_umur0(di, de, du);
       const pi_id = requestInputID(de, du, 'periode_isolation') || pc_id;


### PR DESCRIPTION
Modified the calc_mur function to include the 'ej' (effet joule) parameter when calling tv_umur for the 'isolation inconnue (table forfaitaire)' case. This ensures that the effet joule variable is considered in the Umur calculation for this specific scenario. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    