### PR TITLE
fix: deperdition_pont_thermique is sometimes not obtained only from pont_thermique_collection

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -165,7 +165,7 @@ export function calcul_3cl(dpe) {
     zc_id,
     th,
     ej,
-    logement,
+    dpe,
     ShChauffageAndEcs,
     ficheTechniqueFacadesExposees
   );


### PR DESCRIPTION
fix https://github.com/jzck/Open3CL/issues/216

Si individuellement les ponts thermiques déclarés et calculés sont identiques, la déperdition totale devrait l'être également.
Pour certains DPE, il réside une différence que l'on prendra en compte pour la suite des calculs.